### PR TITLE
Fix BundleName incompatibility with old PayseraRestBundle

### DIFF
--- a/src/DependencyInjection/MabaPayseraRestExtension.php
+++ b/src/DependencyInjection/MabaPayseraRestExtension.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
-class PayseraRestExtension extends Extension
+class MabaPayseraRestExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container)
     {

--- a/src/PayseraRestBundle.php
+++ b/src/PayseraRestBundle.php
@@ -9,6 +9,8 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class PayseraRestBundle extends Bundle
 {
+    protected $name = 'MabaPayseraRestBundle';
+
     public function build(ContainerBuilder $container)
     {
         parent::build($container);


### PR DESCRIPTION
Fix BundleName incompatibility when old PayseraRestBundle is installed as BundleName is resolved from it's ClassName